### PR TITLE
Update Makefile to fix composer install crash, should be 10.3 not 9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ PLATFORM := $(shell uname -s)
 $(eval GIT_USERNAME := $(if $(GIT_USERNAME),$(GIT_USERNAME),gitlab-ci-token))
 $(eval GIT_PASSWORD := $(if $(GIT_PASSWORD),$(GIT_PASSWORD),$(CI_JOB_TOKEN)))
 DOCKER_REPO := https://github.com/drupalwxt/docker-scaffold.git
-GET_DOCKER := $(shell [ -d docker ] || git clone --branch 9.2.x $(DOCKER_REPO) docker)
+GET_DOCKER := $(shell [ -d docker ] || git clone --branch 10.3.x $(DOCKER_REPO) docker)
 include docker/Makefile


### PR DESCRIPTION
Without this fix, any project based on this build will crash when running the make command , the make command does a scaffold build.